### PR TITLE
pyyaml version update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ librosa
 more_itertools
 scipy==1.3.2
 scikit-learn
-pyyaml
+pyyaml==5.4.1
 pydub
 deepspeech
 nltk


### PR DESCRIPTION
Recently released pyyaml version creating "TypeError: load() missing 1 required positional argument: 'Loader'" error.

- Fixed the pyyaml version to 5.4.1