### PR TITLE
add .gitattributes to handle line separator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+# Never modify line endings of our bash scripts
+*.sh eol=lf
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.py            text
+*.css           text
+*.html          text
+*.java          text
+*.js            text
+*.json          text
+*.properties    text
+*.txt           text
+*.xml           text
+
+# These files are binary and should be left untouched
+# (binary is macro for -text -diff)
+*.class         binary
+*.jar           binary
+*.gif           binary
+*.jpg           binary
+*.png           binary

--- a/process_dbm.sh
+++ b/process_dbm.sh
@@ -79,5 +79,4 @@ fi
 docker cp dbm_container:/app/output $output_path
 docker stop dbm_container
 docker rm dbm_container
-
 exit


### PR DESCRIPTION
**Reference Issues/PRs**
Solve #41 


**What does this implement/fix? Explain your changes.**

This issue only happened when the developer checkout the repo using global config `core.autocrlf = True`.

I have this PR because in the future, developers that are using Windows sometimes set their git global config `core.autocrlf` to True. When they checkout files, It will change the bash script to CRLF instead of LF, breaking the script.

This PR implements solutions:
1. Add file `.gitattributes` which will normalize files. specifically, for bash script, it will be consistently set to LF.
2. reupload the shell script to convert CRLF to LF again.


**Affected Change**
.gitattributes (new file)